### PR TITLE
Add ability to accept a component which will be rendered during loading.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,8 @@ var paginationContainer = exports.paginationContainer = function paginationConta
   };
 };
 
-var queryRenderer = exports.queryRenderer = function queryRenderer(rootQuery, variables) {
+var queryRenderer = exports.queryRenderer = function queryRenderer(rootQuery, variables, LoadingComponent) {
+  var loadingComponentProps = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
   return function (Component) {
     var _class, _temp;
 
@@ -86,6 +87,8 @@ var queryRenderer = exports.queryRenderer = function queryRenderer(rootQuery, va
                   retry = _ref.retry;
 
               if (!props && !error) {
+                var toRenderDuringLoading = LoadingComponent ? _react2.default.createElement(LoadingComponent, loadingComponentProps) : null;
+
                 return null;
               }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ var queryRenderer = exports.queryRenderer = function queryRenderer(rootQuery, va
               if (!props && !error) {
                 var toRenderDuringLoading = LoadingComponent ? _react2.default.createElement(LoadingComponent, loadingComponentProps) : null;
 
-                return null;
+                return toRenderDuringLoading;
               }
 
               return _react2.default.createElement(Component, _extends({}, props, _this2.props, {

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export const queryRenderer = (rootQuery, variables, LoadingComponent, loadingCom
                 ? <LoadingComponent {...loadingComponentProps} />
                 : null;
 
-              return null;
+              return toRenderDuringLoading;
             }
 
             return (

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export const paginationContainer = (query, connectionConfig) => Component => cre
   connectionConfig,
 );
 
-export const queryRenderer = (rootQuery, variables) =>
+export const queryRenderer = (rootQuery, variables, LoadingComponent, loadingComponentProps = {}) =>
   Component => class RelayRoot extends React.Component {
     static displayName = `RelayRoot(${Component.displayName})`
 
@@ -48,6 +48,10 @@ export const queryRenderer = (rootQuery, variables) =>
           variables={vars}
           render={({ error, props, retry }) => {
             if (!props && !error) {
+              const toRenderDuringLoading = LoadingComponent
+                ? <LoadingComponent {...loadingComponentProps} />
+                : null;
+
               return null;
             }
 
@@ -62,8 +66,8 @@ export const queryRenderer = (rootQuery, variables) =>
           }}
         />
       );
-  }
-};
+    }
+  };
 
 export const refetchContainer = (renderVariables, query) => Component => createRefetchContainer(
   Component,


### PR DESCRIPTION
In case you want to show a spinner, now you can pass a component and its props to queryRenderer.

```js
compose(
  // ... some other functions in the chain
  queryRenderer(myQuery, myVars, MyLoadingComponent, myLoadingComponentProps),
  // ... some other functions in the chain
)
```

P.S: It would be great if you could merge and release it quickly because I need this to show a spinner when data is loading 😄 . Thank you.